### PR TITLE
composer: specify php version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,9 @@
             "email": "acurrieclark@gmail.com"
         }
     ],
-    "require": {},
+    "require": {
+        "php": "^5.4.0 || ^7.0"
+    },
     "autoload": {
         "psr-4": {
             "acurrieclark\\PhpPasswordVerifier\\": "src"


### PR DESCRIPTION
for some of us it's important to know min php engine requirements.
i did not look closely what it is here, but i saw you used short array constructs. so at least 5.4 is required